### PR TITLE
✅ #S4U-35 | Adicionando automações de Lista Padrão

### DIFF
--- a/cypress/integration/04-Lista-Padrao.feature
+++ b/cypress/integration/04-Lista-Padrao.feature
@@ -1,0 +1,41 @@
+Feature: Lista Padrão
+
+    Como usuário logado, desejo acessar o menu Lista Padrão
+    Para visualizar as Lista Padrões cadastradas e adicionar novas
+
+Scenario: Validacoes gerais da tela de Lista Padrão
+    Given que sou um prestador cadastrado
+    When efetuo login com sucesso
+    And clico no menu Lista Padrão 
+    Then devo visualizar o título Lista Padrão
+    And o botão Adicionar nova lista
+    And visualizar as colunas Nome e Ações
+    And a listagem de listas já cadastrados ou não.
+
+Scenario: Cadastro de Lista Padrão com sucesso
+    Given que sou um prestador cadastrado
+    When acesso a tela de Lista Padrão
+    And clico no botão Adicionar nova lista 
+    And após preencher os dados de Nome da lista, Produto, Quantidade,  Unidade-Medida
+    Then ao clicar nos botões Adicionar e Enviar, devo receber uma mensagem de sucesso
+    And visualizar a lista na listagem após fechar o modal
+
+Scenario: Visualizar informações de Lista Padrão
+    Given que sou um prestador cadastrado
+    When acesso a tela de Lista Padrão
+    And clico no botão Visualizar na coluna Ações de determinado lista
+    Then devo visualizar o título Lista Padrão, os botões Imprimir lista e Voltar
+    And as colunas Nome, Quantidade, Unidade-Medida
+    And as informações de itens pertencentes à lista
+
+Scenario: Imprimir Lista Padrão
+    Given que sou um prestador cadastrado
+    When acesso a tela de Lista Padrão
+    And clico no botão Visualizar na coluna Ações de determinado lista
+    Then ao clicar no botão Imprimir lista devo ser direcionado para a tela de impressão
+
+Scenario: Excluir Lista Padrão
+    Given que sou um prestador cadastrado
+    When acesso a tela de Lista Padrão
+    And clico no botão Excluir na coluna Ações de determinado lista
+    Then a Lista Padrão em questão deve ser removida da lista

--- a/cypress/integration/04-Lista-Padrao/steps.js
+++ b/cypress/integration/04-Lista-Padrao/steps.js
@@ -1,0 +1,128 @@
+Given(/^que sou um prestador cadastrado$/, () => {
+  return true
+})
+
+When(/^efetuo login com sucesso$/, () => {
+  cy.visit('/')
+})
+
+When(/^clico no menu Lista Padrão$/, () => {
+  cy.get('[href="/lista-padrao"]').click()
+})
+
+Then(/^devo visualizar o título Lista Padrão$/, () => {
+  cy.get('.sc-hHfuMS').should('contain', 'Lista Padrão')
+})
+
+Then(/^o botão Adicionar nova lista$/, () => {
+  cy.get('.MuiButtonBase-root').should('contain', 'Adicionar Nova lista')
+})
+
+Then(/^visualizar as colunas Nome e Ações$/, () => {
+  cy.get('thead > tr > :nth-child(1)').should('contain', 'Nome')
+  cy.get('thead > tr > :nth-child(2)').should('contain', 'Ações')
+})
+
+Then(/^a listagem de listas já cadastrados ou não.$/, () => {
+  cy.get('tbody').should('be.visible')
+})
+When(/^acesso a tela de Lista Padrão$/, () => {
+  cy.visit('/')
+  cy.get('[href="/lista-padrao"]').click()
+})
+
+When(/^clico no botão Adicionar nova lista$/, () => {
+  cy.get('.MuiButtonBase-root').click()
+})
+
+When(
+  /^após preencher os dados de Nome da lista, Produto, Quantidade,  Unidade-Medida$/,
+  () => {
+    cy.get('.sc-bBXrwG > .input-group > .form-control').type(
+      'Nova Lista Padrão'
+    )
+    cy.get('.mySelect__value-container.css-319lph-ValueContainer').type(
+      '233{enter}'
+    )
+    cy.get('.sc-lmoMya > :nth-child(2) > .input-group > .form-control').type(
+      '5'
+    )
+    cy.get('.btn').click()
+    cy.get('.mySelect__value-container.css-319lph-ValueContainer').type(
+      '321321{enter}'
+    )
+    cy.get('.sc-lmoMya > :nth-child(2) > .input-group > .form-control')
+      .clear()
+      .type('2')
+  }
+)
+
+Then(
+  /^ao clicar nos botões Adicionar e Enviar, devo receber uma mensagem de sucesso$/,
+  () => {
+    cy.get('.btn').click()
+    cy.get('.makeStyles-root-18').click()
+    cy.get('.Toastify__toast-body').should(
+      'contain',
+      'Lista adicionada com sucesso'
+    )
+  }
+)
+
+Then(/^visualizar a lista na listagem após fechar o modal$/, () => {
+  cy.get('.makeStyles-voltar-19').click()
+  cy.get('tbody >> :nth-child(1)').last().should('contain', 'Lista Padrão')
+})
+Then(/^clico no botão Visualizar na coluna Ações de determinado lista$/, () => {
+  cy.get(':nth-child(2) > .btn-primary').last().click()
+})
+
+Then(
+  /^devo visualizar o título Lista Padrão, os botões Imprimir lista e Voltar$/,
+  () => {
+    cy.get('.sc-jJEKmz').last().should('contain', 'Lista Padrão')
+    cy.get('.makeStyles-root-18').last().should('contain', 'Imprimir lista')
+    cy.get('.makeStyles-voltar-19').last().should('contain', 'Voltar')
+  }
+)
+
+Then(/^as colunas Nome, Quantidade, Unidade-Medida$/, () => {
+  cy.get('thead > tr > :nth-child(1)').should('contain', 'Nome')
+  cy.get('thead > tr > :nth-child(2)').should('contain', 'Quantidade')
+  cy.get('thead > tr > :nth-child(3)').should('contain', 'Unidade - Medida')
+})
+
+Then(/^as informações de itens pertencentes à lista$/, () => {
+  cy.get('tbody > :nth-child(1) > :nth-child(1)').should('contain', '233')
+  cy.get('tbody > :nth-child(1) > :nth-child(2)').should('contain', '5')
+  cy.get('tbody > :nth-child(1) > :nth-child(3)').should('contain', '22222')
+  cy.get('tbody > :nth-child(2) > :nth-child(1)').should('contain', '321321')
+  cy.get('tbody > :nth-child(2) > :nth-child(2)').should('contain', '2')
+  cy.get('tbody > :nth-child(2) > :nth-child(3)').should('contain', '321321')
+})
+
+Then(
+  /^ao clicar no botão Imprimir lista devo ser direcionado para a tela de impressão$/,
+  () => {
+    cy.visit('/').then(xhr => {
+      cy.window().then(function (win) {
+        cy.stub(win, 'print')
+        cy.get('[href="/lista-padrao"]').click()
+        cy.get(':nth-child(2) > .btn-primary').last().click()
+        cy.get('.makeStyles-root-18')
+          .click()
+          .then(() => {
+            expect(win.print).to.be.called
+          })
+      })
+    })
+  }
+)
+
+Then(/^clico no botão Excluir na coluna Ações de determinado lista$/, () => {
+  cy.get(':nth-child(2) > .btn-danger').last().click()
+})
+
+Then(/^a Lista Padrão em questão deve ser removida da lista$/, () => {
+  cy.contains('Nova Lista Padrão').should('not.exist')
+})

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@typescript-eslint/parser": "4.29.3",
     "babel-eslint": "10.1.0",
     "customize-cra": "^1.0.0",
-    "cypress": "^8.6.0",
+    "cypress": "9.0.0",
     "cypress-cucumber-preprocessor": "^4.3.0",
     "eslint": "7.32.0",
     "eslint-config-prettier": "8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1373,10 +1373,10 @@
     through2 "^2.0.0"
     watchify "^4.0.0"
 
-"@cypress/request@^2.88.6":
-  version "2.88.6"
-  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.6.tgz#a970dd675befc6bdf8a8921576c01f51cc5798e9"
-  integrity sha512-z0UxBE/+qaESAHY9p9sM2h8Y4XqtsbDCt0/DPOrqA/RZgKi4PkxdpXyK4wCCnSk1xHqWHZZAE+gV6aDAR6+caQ==
+"@cypress/request@^2.88.7":
+  version "2.88.7"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.7.tgz#386d960ab845a96953723348088525d5a75aaac4"
+  integrity sha512-FTULIP2rnDJvZDT9t6B4nSfYR40ue19tVmv3wUcY05R9/FPCoMl1nAPJkzWzBCo7ltVn5ThQTbxiMoGBN7k0ig==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -5548,12 +5548,12 @@ cypress-cucumber-preprocessor@^4.3.0:
     minimist "^1.2.5"
     through "^2.3.8"
 
-cypress@^8.6.0:
-  version "8.7.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-8.7.0.tgz#2ee371f383d8f233d3425b6cc26ddeec2668b6da"
-  integrity sha512-b1bMC3VQydC6sXzBMFnSqcvwc9dTZMgcaOzT0vpSD+Gq1yFc+72JDWi55sfUK5eIeNLAtWOGy1NNb6UlhMvB+Q==
+cypress@9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.0.0.tgz#8c496f7f350e611604cc2f77b663fb81d0c235d2"
+  integrity sha512-/93SWBZTw7BjFZ+I9S8SqkFYZx7VhedDjTtRBmXO0VzTeDbmxgK/snMJm/VFjrqk/caWbI+XY4Qr80myDMQvYg==
   dependencies:
-    "@cypress/request" "^2.88.6"
+    "@cypress/request" "^2.88.7"
     "@cypress/xvfb" "^1.2.4"
     "@types/node" "^14.14.31"
     "@types/sinonjs__fake-timers" "^6.0.2"
@@ -5588,7 +5588,6 @@ cypress@^8.6.0:
     ospath "^1.2.2"
     pretty-bytes "^5.6.0"
     proxy-from-env "1.0.0"
-    ramda "~0.27.1"
     request-progress "^3.0.0"
     supports-color "^8.1.1"
     tmp "~0.2.1"
@@ -11873,11 +11872,6 @@ raf@^3.4.1:
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
   dependencies:
     performance-now "^2.1.0"
-
-ramda@~0.27.1:
-  version "0.27.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
-  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Foram adicionados 5 novos cenários de teste da feature de Lista Padrão:

- Validações gerais ✅
    
    **Dado que** sou um prestador cadastrado
    **Quando** efetuo login com sucesso
    **E** clico no menu **Lista Padrão** 
    **Então** devo visualizar o título **Lista Padrão**
    **E** o botão **Adicionar nova lista**
    **E** visualizar as colunas **Nome** e **Ações
    E** a listagem de listas já cadastrados ou não.
    
- Cadastro de Lista Padrão com sucesso ✅
    
    **Dado que** sou um prestador cadastrado
    **Quando** acesso a tela de Lista Padrão
    **E** clico no botão **Adicionar nova lista** 
    **E** após preencher os dados de **Nome da lista, Produto, Quantidade,**  **Unidade-Medida
    Então** ao clicar nos botões **Adicionar** e **Enviar,** devo receber uma mensagem de sucesso
    **E** visualizar a lista na listagem após fechar o modal
    
- Visualizar informações de Lista Padrão ✅
    
    **Dado que** sou um prestador cadastrado
    **Quando** acesso a tela de **Lista Padrão**
    **E** clico no botão **Visualizar** na coluna Ações de determinado lista
    **Então** devo visualizar o título **Lista Padrão**, os botões **Imprimir lista** e **Voltar
    E** as colunas **Nome, Quantidade, Unidade-Medida
    E** as informações de itens pertencentes à lista
    
- Imprimir Lista Padrão ✅
    
    **Dado que** sou um prestador cadastrado
    **Quando** acesso a tela de **Lista Padrão**
    **E** clico no botão **Visualizar** na coluna Ações de determinado lista
    **Então** ao clicar no botão **Imprimir lista** devo ser direcionado para a tela de impressão
    
- Excluir Lista Padrão ✅
    
    **Dado que** sou um prestador cadastrado
    **Quando** acesso a tela de Lista Padrão
    **E** clico no botão Excluir na coluna Ações de determinado lista
    **Então** a Lista Padrão em questão deve ser removida da lista